### PR TITLE
Abbreviate `button` as `btn`

### DIFF
--- a/modules/shorthand_dictionary.md
+++ b/modules/shorthand_dictionary.md
@@ -18,6 +18,7 @@ context: inner-page
     b - body | bottom
     bg - background
     brd - border
+    btn - button
 
     cat - catalog | category
     cl - clear


### PR DESCRIPTION
Word `button` can be abbreviated as `btn`.
This abbreviation is already common to users of Twitter Bootstrap and seems to be clear enough to understand even w/o a dictionary.
